### PR TITLE
Visual cleanup. Remove helm 'coming soon' placeholder page until we decide what should go there

### DIFF
--- a/docs/examples/helm.md
+++ b/docs/examples/helm.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 7
----
-
-# Helm Charts
-
-Weave GitOps supports deploying existing Helm Charts. 
-
-More information coming soon!

--- a/docs/gitops-automation.md
+++ b/docs/gitops-automation.md
@@ -55,7 +55,7 @@ It defines the name of the application and the git url location of the repositor
 ### `app-gitops-runtime.yaml`
 This file defines the flux runtime flow to deploy the application into a specific target. 
 For example, by default this uses the [flux kustomize](https://fluxcd.io/docs/components/kustomize/kustomization/) support
-to deploy your application manifests into the cluster. Other options include [managing helm charts](examples/helm.md).
+to deploy your application manifests into the cluster. Other options include managing helm charts.
 ```yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1

--- a/versioned_docs/version-0.0.5/examples/_category_.json
+++ b/versioned_docs/version-0.0.5/examples/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Examples",
-  "position": 6
-}

--- a/versioned_docs/version-0.0.5/examples/helm.md
+++ b/versioned_docs/version-0.0.5/examples/helm.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 7
----
-
-# Helm Charts
-
-Weave GitOps supports deploying existing Helm Charts. 
-
-More information coming soon!

--- a/versioned_docs/version-0.0.5/gitops-automation.md
+++ b/versioned_docs/version-0.0.5/gitops-automation.md
@@ -55,7 +55,7 @@ It defines the name of the application and the git url location of the repositor
 ### `app-gitops-runtime.yaml`
 This file defines the flux runtime flow to deploy the application into a specific target. 
 For example, by default this uses the [flux kustomize](https://fluxcd.io/docs/components/kustomize/kustomization/) support
-to deploy your application manifests into the cluster. Other options include [managing helm charts](/docs/examples/helm).
+to deploy your application manifests into the cluster. Other options include managing helm charts.
 ```yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1

--- a/versioned_docs/version-0.2.0/examples/_category_.json
+++ b/versioned_docs/version-0.2.0/examples/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Examples",
-  "position": 6
-}

--- a/versioned_docs/version-0.2.0/examples/helm.md
+++ b/versioned_docs/version-0.2.0/examples/helm.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 7
----
-
-# Helm Charts
-
-Weave GitOps supports deploying existing Helm Charts. 
-
-More information coming soon!

--- a/versioned_docs/version-0.2.0/gitops-automation.md
+++ b/versioned_docs/version-0.2.0/gitops-automation.md
@@ -55,7 +55,7 @@ It defines the name of the application and the git url location of the repositor
 ### `app-gitops-runtime.yaml`
 This file defines the flux runtime flow to deploy the application into a specific target. 
 For example, by default this uses the [flux kustomize](https://fluxcd.io/docs/components/kustomize/kustomization/) support
-to deploy your application manifests into the cluster. Other options include [managing helm charts](examples/helm.md).
+to deploy your application manifests into the cluster. Other options include managing helm charts.
 ```yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1

--- a/versioned_docs/version-0.2.1/examples/_category_.json
+++ b/versioned_docs/version-0.2.1/examples/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Examples",
-  "position": 6
-}

--- a/versioned_docs/version-0.2.1/examples/helm.md
+++ b/versioned_docs/version-0.2.1/examples/helm.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 7
----
-
-# Helm Charts
-
-Weave GitOps supports deploying existing Helm Charts. 
-
-More information coming soon!

--- a/versioned_docs/version-0.2.1/gitops-automation.md
+++ b/versioned_docs/version-0.2.1/gitops-automation.md
@@ -55,7 +55,7 @@ It defines the name of the application and the git url location of the repositor
 ### `app-gitops-runtime.yaml`
 This file defines the flux runtime flow to deploy the application into a specific target. 
 For example, by default this uses the [flux kustomize](https://fluxcd.io/docs/components/kustomize/kustomization/) support
-to deploy your application manifests into the cluster. Other options include [managing helm charts](examples/helm.md).
+to deploy your application manifests into the cluster. Other options include managing helm charts.
 ```yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1

--- a/versioned_docs/version-0.2.2/examples/_category_.json
+++ b/versioned_docs/version-0.2.2/examples/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Examples",
-  "position": 6
-}

--- a/versioned_docs/version-0.2.2/examples/helm.md
+++ b/versioned_docs/version-0.2.2/examples/helm.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 7
----
-
-# Helm Charts
-
-Weave GitOps supports deploying existing Helm Charts. 
-
-More information coming soon!

--- a/versioned_docs/version-0.2.2/gitops-automation.md
+++ b/versioned_docs/version-0.2.2/gitops-automation.md
@@ -55,7 +55,7 @@ It defines the name of the application and the git url location of the repositor
 ### `app-gitops-runtime.yaml`
 This file defines the flux runtime flow to deploy the application into a specific target. 
 For example, by default this uses the [flux kustomize](https://fluxcd.io/docs/components/kustomize/kustomization/) support
-to deploy your application manifests into the cluster. Other options include [managing helm charts](examples/helm.md).
+to deploy your application manifests into the cluster. Other options include managing helm charts.
 ```yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1


### PR DESCRIPTION
@jrryjcksn This removes the placeholder, which just looks unfinished (and is already addressed in the getting started page). In `main` it keeps your sock shop page under examples/,