### PR TITLE
New upgrade instructions

### DIFF
--- a/docs/enterprise/upgrading.mdx
+++ b/docs/enterprise/upgrading.mdx
@@ -12,13 +12,10 @@ Upgrading requires we:
 
 1. Already have Weave GitOps [installed on the cluster](../getting-started.md)
 2. Install Profiles onto the cluster
-3. Install the `mccp` cli tool
-4. Apply the entitlements secret
-5. Create a secret for docker repository
-6. Create a secret for creating pull requests on your git provider
-7. Upgrade
-8. Configure
-9. Check that Weave Gitops Enterprise has been installed
+3. Apply the entitlements secret
+4. Upgrade
+5. Configure
+6. Check that Weave Gitops Enterprise has been installed
 
 ### 2. Install profiles
 
@@ -34,20 +31,7 @@ Download the latest `pctl` [release](https://github.com/weaveworks/pctl/releases
 pctl install --flux-namespace wego-system
 ```
 
-### 3. Install the MCCP CLI
-
-:::note This step will be removed
-
-This step will be removed when the `upgrade` command moves into the `gitops` binary
-
-:::
-
-The MCCP CLI allows you to `upgrade` to Weave Gitops Enterprise. You can also use `mccp` to manage the lifecycle of your infrastructure declaratively using GitOps. The latest version of the MCCP CLI is available in the following links:
-
-- [Linux](https://s3.amazonaws.com/weaveworks-wkp/releases/mccp-v0.0.10-linux-amd64)
-- [macOS](https://s3.amazonaws.com/weaveworks-wkp/releases/mccp-v0.0.10-linux-amd64)
-
-### 4. Apply the entitlements secret
+### 3. Apply the entitlements secret
 
 Contact sales@weave.works for a valid entitlements secret. Then apply it to the cluster:
 
@@ -55,62 +39,22 @@ Contact sales@weave.works for a valid entitlements secret. Then apply it to the 
 kubectl apply -f entitlements.yaml
 ```
 
-### 5. Creating a secret for docker repository
-
-:::note This step will be removed
-
-This step will be removed when the Docker Image repositories become public
-
-:::
-
-Create a secret that contains your docker repository credentials. This secret will be used by Kubernetes during deployment in order to pull down the WGE images. You can find instructions on how to generate this secret [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
-
-```bash
-$ kubectl create secret docker-registry \
-  --namespace wego-system docker-io-pull-secret \
-  --docker-username=<your-docker-username> \
-  --docker-password=<your-docker-password>
-```
-
-If you use a secrets management solution such as Sealed Secrets follow their instructions on how to create a new secret.
-
-### 6. Create a secret for creating pull requests on your git provider
-
-A Personal Access Token is required for the WGE to create pull requests for new clusters. These tokens need certain permissions (scopes) set. For
-
-- GitHub: `repo`
-- GitLab: `api`
-
-Save the token in secret called `git-provider-credentials`.
-
-```bash
-kubectl create secret generic git-provider-credentials \
-  --namespace=wego-system
-  --from-literal="GIT_PROVIDER_TOKEN=$GITHUB_TOKEN"
-```
-
-### 7. Upgrade
-
-:::note This step will change
-
-This will change when the `upgrade` command moves into the `gitops` binary
-
-:::
+### 4. Upgrade
 
 Run the upgrade command from a local copy of git repo that is sync'd to the cluster:
 
 ```bash
 cd my-cluster-repo
-mccp upgrade
+gitops upgrade
 ```
 
 A **Pull Request** will be created against your cluster repository. **Review and merge** this pull request to upgrade to Weave Gitops Enterprise.
 
-### 8. Configure Weave Gitops Enterprise
+### 5. Configure Weave Gitops Enterprise
 
 Weave Gitops Enterprise has a number of configration options but two importants aspect to configure are:
 
-#### 8.1. Ingress
+#### 5.1. Ingress
 
 An Ingress address is necessary in order to establish connectivity between agents and your WGE instance. The way to determine this depends on your cluster type and provisioning method.
 
@@ -143,7 +87,7 @@ export INGRESS_ADDRESS=wge.example.com
 
 Update the `agentTemplate.natsURL` value in the Weave Gitops Enterprise `ConfigMap` in your config repo.
 
-#### 8.2. Git repository configuration
+#### 5.2. Git repository configuration
 
 WGE will make pull requests against your git config repo when creating new CAPI clusters etc. The `GIT_PROVIDER_TOKEN` in the `git-provider-credentials` secret specified above will be used to authenticate.
 
@@ -155,7 +99,7 @@ After configuring values in the `ConfigMap` you may have to delete the cluster-s
 
 :::
 
-### 9. Checking that WGE is installed
+### 6. Checking that WGE is installed
 
 You should now be able to load the WGE UI by running the following command:
 


### PR DESCRIPTION
- After
  - removing pull secret and git token
  - `upgrade` moved into `gitops` command