### PR TITLE
Minor updates to the upgrade docs

### DIFF
--- a/docs/cluster-management/getting-started.mdx
+++ b/docs/cluster-management/getting-started.mdx
@@ -39,7 +39,7 @@ Download the template below to your config repository path, then commit and push
     <CodeBlock className="language-bash">
       curl -o .weave-gitops/apps/capi/templates/capd-template.yaml{" "}
       {window.location.protocol}//{window.location.host}
-      {require("./assets/bootstrap/calico-crs.yaml").default}
+      {require("./assets/templates/capd-template.yaml").default}
     </CodeBlock>
   )}
 </BrowserOnly>

--- a/docs/enterprise/upgrading.mdx
+++ b/docs/enterprise/upgrading.mdx
@@ -6,12 +6,17 @@ sidebar_position: 0
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-## How to: Upgrade to Weave Gitops Enterprise
+## How to: Upgrade to Weave GitOps Enterprise
 
-:::note gitops >= 0.5.0-rc2 version required
+:::note BEFORE YOU START 
 
-Make sure `gitops version` is reporting a version >= `0.5.0-rc2` before continuing with these instructions. Download releases of Weave Gitops from [the releases page](https://github.com/weaveworks/weave-gitops/releases).
+  Make sure the following software is installed before continuing with these instructions:
+  
+  - `gitops` >= 0.5.0-rc2. Use `gitops version` to check the currently installed version. If needed, download a newer version of Weave GitOps from the [releases page](https://github.com/weaveworks/weave-gitops/releases).
+  - `clusterctl` >= 1.0.1. Use `clusterctl version` to check the currently installed version. If needed, download a newer version of clusterctl from the [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
 
+
+  Also `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
 :::
 
 Upgrading requires we:
@@ -20,7 +25,7 @@ Upgrading requires we:
 2. Install a CAPI provider
 3. Apply the entitlements secret
 4. Upgrade
-5. Check that Weave Gitops Enterprise has been installed
+5. Check that Weave GitOps Enterprise has been installed
 6. Connect the management cluster up to itself
 
 ### 1. Install `gitops` on a new cluster
@@ -80,10 +85,6 @@ In order to be able to provision Kubernetes clusters, a CAPI provider needs to b
 clusterctl init --infrastructure docker
 ```
 
-:::note clusterctl >= 1.0.0 version required
-
-:::
-
 ### 3. Apply the entitlements secret
 
 Contact sales@weave.works for a valid entitlements secret. Then apply it to the cluster:
@@ -96,19 +97,13 @@ kubectl apply -f entitlements.yaml
 
 ### 4. Upgrade
 
-:::note Make sure `GITHUB_TOKEN` is set
-
-`GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo
-
-:::
-
 Run the upgrade command from a local copy of git repo that is sync'd to the cluster:
 
 ```bash
 gitops upgrade --profile-version 0.0.16 --app-config-url $(git config --get remote.origin.url)
 ```
 
-A **Pull Request** will be created against your cluster repository. **Review and merge** this pull request to upgrade to Weave Gitops Enterprise.
+A **Pull Request** will be created against your cluster repository. **Review and merge** this pull request to upgrade to Weave GitOps Enterprise.
 
 ### 5. Checking that WGE is installed
 

--- a/docs/enterprise/upgrading.mdx
+++ b/docs/enterprise/upgrading.mdx
@@ -17,10 +17,11 @@ Make sure `gitops version` is reporting a version >= `0.5.0-rc2` before continui
 Upgrading requires we:
 
 1. Have a cluster with Weave GitOps installed
-2. Apply the entitlements secret
-3. Upgrade
-4. Check that Weave Gitops Enterprise has been installed
-5. Connect the management cluster up to itself
+2. Install a CAPI provider
+3. Apply the entitlements secret
+4. Upgrade
+5. Check that Weave Gitops Enterprise has been installed
+6. Connect the management cluster up to itself
 
 ### 1. Install `gitops` on a new cluster
 
@@ -71,7 +72,19 @@ Install Weave Gitops
 gitops install --app-config-url $(git config --get remote.origin.url)
 ```
 
-### 2. Apply the entitlements secret
+### 2. Install a CAPI provider
+
+In order to be able to provision Kubernetes clusters, a CAPI provider needs to be installed.
+
+```
+clusterctl init --infrastructure docker
+```
+
+:::note clusterctl >= 1.0.0 version required
+
+:::
+
+### 3. Apply the entitlements secret
 
 Contact sales@weave.works for a valid entitlements secret. Then apply it to the cluster:
 
@@ -79,7 +92,9 @@ Contact sales@weave.works for a valid entitlements secret. Then apply it to the 
 kubectl apply -f entitlements.yaml
 ```
 
-### 3. Upgrade
+
+
+### 4. Upgrade
 
 :::note Make sure `GITHUB_TOKEN` is set
 
@@ -95,7 +110,7 @@ gitops upgrade --profile-version 0.0.16 --app-config-url $(git config --get remo
 
 A **Pull Request** will be created against your cluster repository. **Review and merge** this pull request to upgrade to Weave Gitops Enterprise.
 
-### 4. Checking that WGE is installed
+### 5. Checking that WGE is installed
 
 You should now be able to load the WGE UI:
 
@@ -105,7 +120,7 @@ kubectl port-forward --namespace wego-system deployments.apps/weave-gitops-enter
 
 The WGE UI should now be accessible at [http://localhost:8000](http://localhost:8000).
 
-### 5. Connect the management cluster up to itself
+### 6. Connect the management cluster up to itself
 
 _Connecting a cluster_ installs the agent which is responsible for detecting new clusters and reporting their status to the UI. We need to install the agent on our newly created management cluster. Check out [How to: Connect a cluster](../cluster-management/managing-existing-clusters.mdx#how-to-connect-a-cluster). The agent should be loaded onto our new management cluster, give it a name like **Management** and leave the Ingress URL blank.
 

--- a/docs/enterprise/upgrading.mdx
+++ b/docs/enterprise/upgrading.mdx
@@ -8,15 +8,13 @@ import TabItem from "@theme/TabItem";
 
 ## How to: Upgrade to Weave GitOps Enterprise
 
-:::note BEFORE YOU START 
+:::note BEFORE YOU START
 
-  Make sure the following software is installed before continuing with these instructions:
-  
-  - `gitops` >= 0.5.0-rc2. Use `gitops version` to check the currently installed version. If needed, download a newer version of Weave GitOps from the [releases page](https://github.com/weaveworks/weave-gitops/releases).
-  - `clusterctl` >= 1.0.1. Use `clusterctl version` to check the currently installed version. If needed, download a newer version of clusterctl from the [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
+Make sure the following software is installed before continuing with these instructions:
 
+- `gitops` >= 0.5.0-rc2. Use `gitops version` to check the currently installed version. If needed, download a newer version of Weave GitOps from the [releases page](https://github.com/weaveworks/weave-gitops/releases).
 
-  Also `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
+Also `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
 :::
 
 Upgrading requires we:
@@ -78,6 +76,13 @@ gitops install --app-config-url https://github.com/my-org/my-repo
 ```
 
 ### 2. Install a CAPI provider
+
+:::note `clusterctl` versions
+
+The example templates provided in this guide have been tested with `clusterctl` version `1.0.1`. However you might need to use an older or newer version depending on the capi-providers you plan use.
+
+Download a specific version of clusterctl from the [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
+:::
 
 In order to be able to provision Kubernetes clusters, a CAPI provider needs to be installed.
 

--- a/docs/enterprise/upgrading.mdx
+++ b/docs/enterprise/upgrading.mdx
@@ -74,7 +74,7 @@ git push -u origin main
 Install Weave Gitops
 
 ```bash
-gitops install --app-config-url $(git config --get remote.origin.url)
+gitops install --app-config-url https://github.com/my-org/my-repo
 ```
 
 ### 2. Install a CAPI provider
@@ -93,14 +93,12 @@ Contact sales@weave.works for a valid entitlements secret. Then apply it to the 
 kubectl apply -f entitlements.yaml
 ```
 
-
-
 ### 4. Upgrade
 
 Run the upgrade command from a local copy of git repo that is sync'd to the cluster:
 
 ```bash
-gitops upgrade --profile-version 0.0.16 --app-config-url $(git config --get remote.origin.url)
+gitops upgrade --app-config-url https://github.com/my-org/my-repo --profile-version 0.0.16
 ```
 
 A **Pull Request** will be created against your cluster repository. **Review and merge** this pull request to upgrade to Weave GitOps Enterprise.


### PR DESCRIPTION
- Moved prereqs to the top
- Requires capi-provider to be installed
- Fix up URL formatting of `--app-config-url`
- Fixes link to capd-template