### PR TITLE
Fix baseUrl

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,7 @@ module.exports = {
   title: "Weave GitOps",
   tagline: "Weave GitOps Documentation",
   url: "https://docs.gitops.weave.works/",
-  baseUrl: "/",
+  baseUrl: "/weave-gitops-docs/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon_150px.png",


### PR DESCRIPTION
Currently the docs site is down. Looking at the config the baseUrl has not being set (but probably [should](https://docusaurus.io/docs/deployment#deploying-to-github-pages)). The error message in https://weaveworks.github.io/weave-gitops-docs/ also points to this.