### PR TITLE
Fixing documents to reflect new comands for gitops

### DIFF
--- a/versioned_docs/version-0.5.0/cluster-management/deleting-a-cluster.mdx
+++ b/versioned_docs/version-0.5.0/cluster-management/deleting-a-cluster.mdx
@@ -23,7 +23,7 @@ import TierLabel from "../_components/TierLabel";
 To delete a cluster or clusters using cli run:
 
 ```
-mccp clusters delete <cluster-name>
+gitops delete cluster <cluster-name>
 ```
 
 Merge the PR to delete the clusters.


### PR DESCRIPTION
Hi all,

I believe that the `mccp clusters delete <cluster-name>`  been transitioned to `gitops delete cluster <cluster-name>`. 

Regards,
Steve Fraser